### PR TITLE
remove sql injection validate

### DIFF
--- a/feature/book/usecase/register_book_request.go
+++ b/feature/book/usecase/register_book_request.go
@@ -48,17 +48,11 @@ func (r RegisterBookRequest) Validate() error {
 	if err := util.StringValidator(r.Title).ValidateLength(1, 255); err != nil {
 		return newError(BadRequest, InvalidRequestError, "title must be between 1 and 255 characters")
 	}
-	if err := util.StringValidator(r.Title).ValidateNoSQLInjection(); err != nil {
-		return newError(BadRequest, InvalidRequestError, "title contains potentially dangerous content")
-	}
 
 	// Description validation
 	if r.Description != nil {
 		if err := util.StringValidator(*r.Description).ValidateLength(0, 500); err != nil {
 			return newError(BadRequest, InvalidRequestError, "description must be less than 500 characters")
-		}
-		if err := util.StringValidator(*r.Description).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "description contains potentially dangerous content")
 		}
 	}
 
@@ -70,9 +64,6 @@ func (r RegisterBookRequest) Validate() error {
 		if err := util.StringValidator(*r.CoverImageURL).ValidateURL(); err != nil {
 			return newError(BadRequest, InvalidRequestError, "cover image URL has invalid format")
 		}
-		if err := util.StringValidator(*r.CoverImageURL).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "cover image URL contains potentially dangerous content")
-		}
 	}
 
 	// URL validation
@@ -83,9 +74,6 @@ func (r RegisterBookRequest) Validate() error {
 		if err := util.StringValidator(*r.URL).ValidateURL(); err != nil {
 			return newError(BadRequest, InvalidRequestError, "URL has invalid format")
 		}
-		if err := util.StringValidator(*r.URL).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "URL contains potentially dangerous content")
-		}
 	}
 
 	// AuthorName validation
@@ -93,18 +81,12 @@ func (r RegisterBookRequest) Validate() error {
 		if err := util.StringValidator(*r.AuthorName).ValidateLength(0, 255); err != nil {
 			return newError(BadRequest, InvalidRequestError, "author name must be less than 255 characters")
 		}
-		if err := util.StringValidator(*r.AuthorName).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "author name contains potentially dangerous content")
-		}
 	}
 
 	// PublisherName validation
 	if r.PublisherName != nil {
 		if err := util.StringValidator(*r.PublisherName).ValidateLength(0, 255); err != nil {
 			return newError(BadRequest, InvalidRequestError, "publisher name must be less than 255 characters")
-		}
-		if err := util.StringValidator(*r.PublisherName).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "publisher name contains potentially dangerous content")
 		}
 	}
 

--- a/feature/book/usecase/register_book_usecase_test.go
+++ b/feature/book/usecase/register_book_usecase_test.go
@@ -194,25 +194,6 @@ func TestRegisterBook(t *testing.T) {
 			},
 		},
 		{
-			name: "Register book failed when title contains SQL injection",
-			setup: func(t *testing.T) RegisterBookRequest {
-				return RegisterBookRequest{
-					UserID: user.ID,
-					Title:  "Book'; DROP TABLE books; --",
-					Genres: []string{testdata.GetGenres()[0]},
-					Status: 0,
-				}
-			},
-			check: func(t *testing.T, req RegisterBookRequest, res *RegisterBookResponse, err error) {
-				require.Error(t, err)
-				var e *Error
-				require.ErrorAs(t, err, &e)
-				require.Equal(t, e.StatusCode, BadRequest)
-				require.Equal(t, e.ErrorCode, InvalidRequestError)
-				require.Contains(t, e.Message, "title contains potentially dangerous content")
-			},
-		},
-		{
 			name: "Register book failed when description exceeds 500 characters",
 			setup: func(t *testing.T) RegisterBookRequest {
 				longDesc := testdata.RandomString(501)
@@ -231,27 +212,6 @@ func TestRegisterBook(t *testing.T) {
 				require.Equal(t, e.StatusCode, BadRequest)
 				require.Equal(t, e.ErrorCode, InvalidRequestError)
 				require.Contains(t, e.Message, "description must be less than 500 characters")
-			},
-		},
-		{
-			name: "Register book failed when description contains SQL injection",
-			setup: func(t *testing.T) RegisterBookRequest {
-				sqlDesc := "Description with <script>alert('xss')</script>"
-				return RegisterBookRequest{
-					UserID:      user.ID,
-					Title:       testdata.RandomString(10),
-					Description: &sqlDesc,
-					Genres:      []string{testdata.GetGenres()[0]},
-					Status:      0,
-				}
-			},
-			check: func(t *testing.T, req RegisterBookRequest, res *RegisterBookResponse, err error) {
-				require.Error(t, err)
-				var e *Error
-				require.ErrorAs(t, err, &e)
-				require.Equal(t, e.StatusCode, BadRequest)
-				require.Equal(t, e.ErrorCode, InvalidRequestError)
-				require.Contains(t, e.Message, "description contains potentially dangerous content")
 			},
 		},
 		{

--- a/feature/book/usecase/update_book_request.go
+++ b/feature/book/usecase/update_book_request.go
@@ -31,17 +31,11 @@ func (r UpdateBookRequest) Validate() error {
 	if err := util.StringValidator(r.Title).ValidateLength(1, 255); err != nil {
 		return newError(BadRequest, InvalidRequestError, "title must be between 1 and 255 characters")
 	}
-	if err := util.StringValidator(r.Title).ValidateNoSQLInjection(); err != nil {
-		return newError(BadRequest, InvalidRequestError, "title contains potentially dangerous content")
-	}
 
 	// Description validation
 	if r.Description != nil {
 		if err := util.StringValidator(*r.Description).ValidateLength(0, 500); err != nil {
 			return newError(BadRequest, InvalidRequestError, "description must be less than 500 characters")
-		}
-		if err := util.StringValidator(*r.Description).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "description contains potentially dangerous content")
 		}
 	}
 
@@ -53,9 +47,6 @@ func (r UpdateBookRequest) Validate() error {
 		if err := util.StringValidator(*r.CoverImageURL).ValidateURL(); err != nil {
 			return newError(BadRequest, InvalidRequestError, "cover image URL has invalid format")
 		}
-		if err := util.StringValidator(*r.CoverImageURL).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "cover image URL contains potentially dangerous content")
-		}
 	}
 
 	// URL validation
@@ -66,9 +57,6 @@ func (r UpdateBookRequest) Validate() error {
 		if err := util.StringValidator(*r.URL).ValidateURL(); err != nil {
 			return newError(BadRequest, InvalidRequestError, "URL has invalid format")
 		}
-		if err := util.StringValidator(*r.URL).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "URL contains potentially dangerous content")
-		}
 	}
 
 	// Author validation
@@ -76,18 +64,12 @@ func (r UpdateBookRequest) Validate() error {
 		if err := util.StringValidator(*r.Author).ValidateLength(0, 255); err != nil {
 			return newError(BadRequest, InvalidRequestError, "author name must be less than 255 characters")
 		}
-		if err := util.StringValidator(*r.Author).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "author name contains potentially dangerous content")
-		}
 	}
 
 	// Publisher validation
 	if r.Publisher != nil {
 		if err := util.StringValidator(*r.Publisher).ValidateLength(0, 255); err != nil {
 			return newError(BadRequest, InvalidRequestError, "publisher name must be less than 255 characters")
-		}
-		if err := util.StringValidator(*r.Publisher).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "publisher name contains potentially dangerous content")
 		}
 	}
 

--- a/feature/book/usecase/update_book_usecase_test.go
+++ b/feature/book/usecase/update_book_usecase_test.go
@@ -176,27 +176,6 @@ func TestUpdateBook(t *testing.T) {
 			},
 		},
 		{
-			name: "Update book failed when title contains SQL injection",
-			setup: func(t *testing.T) UpdateBookRequest {
-				return UpdateBookRequest{
-					UserID: user.ID,
-					BookID: registerBookRes.Book.ID,
-					Title:  "Book'; DROP TABLE books; --",
-					Genres: registerBookRes.Book.Genres,
-					Status: domain.Reading,
-				}
-			},
-			check: func(t *testing.T, res *UpdateBookResponse, err error) {
-				require.Error(t, err)
-				require.Nil(t, res)
-				var e *Error
-				require.ErrorAs(t, err, &e)
-				require.Equal(t, BadRequest, e.StatusCode)
-				require.Equal(t, InvalidRequestError, e.ErrorCode)
-				require.Contains(t, e.Message, "title contains potentially dangerous content")
-			},
-		},
-		{
 			name: "Update book failed when description exceeds 500 characters",
 			setup: func(t *testing.T) UpdateBookRequest {
 				longDesc := testdata.RandomString(501)

--- a/feature/user/usecase/sign_in_request.go
+++ b/feature/user/usecase/sign_in_request.go
@@ -30,9 +30,6 @@ func (r SignInRequest) Validate() error {
 	if err := util.StringValidator(r.Email).ValidateEmail(); err != nil {
 		return newError(BadRequest, InvalidRequestError, "email has invalid format")
 	}
-	if err := util.StringValidator(r.Email).ValidateNoSQLInjection(); err != nil {
-		return newError(BadRequest, InvalidRequestError, "email contains potentially dangerous content")
-	}
 
 	// Password validation
 	if len(r.Password) == 0 {
@@ -41,17 +38,11 @@ func (r SignInRequest) Validate() error {
 	if err := util.StringValidator(r.Password).ValidatePassword(); err != nil {
 		return newError(BadRequest, InvalidRequestError, err.Error())
 	}
-	if err := util.StringValidator(r.Password).ValidateNoSQLInjection(); err != nil {
-		return newError(BadRequest, InvalidRequestError, "password contains potentially dangerous content")
-	}
 
 	// IPAddress validation (optional but validate if provided)
 	if len(r.IPAddress) > 0 {
 		if net.ParseIP(r.IPAddress) == nil {
 			return newError(BadRequest, InvalidRequestError, "IP address has invalid format")
-		}
-		if err := util.StringValidator(r.IPAddress).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "IP address contains potentially dangerous content")
 		}
 	}
 
@@ -59,9 +50,6 @@ func (r SignInRequest) Validate() error {
 	if len(r.UserAgent) > 0 {
 		if err := util.StringValidator(r.UserAgent).ValidateLength(0, 2048); err != nil {
 			return newError(BadRequest, InvalidRequestError, "user agent must be less than 2048 characters")
-		}
-		if err := util.StringValidator(r.UserAgent).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "user agent contains potentially dangerous content")
 		}
 	}
 

--- a/feature/user/usecase/sign_in_usecase_test.go
+++ b/feature/user/usecase/sign_in_usecase_test.go
@@ -154,24 +154,6 @@ func TestSignIn(t *testing.T) {
 			},
 		},
 		{
-			name: "Sign in failed when email contains SQL injection",
-			setup: func(t *testing.T) SignInRequest {
-				return SignInRequest{
-					Email:    "user.select@example.com",
-					Password: password,
-				}
-			},
-			check: func(t *testing.T, req SignInRequest, res *SignInResponse, err error) {
-				require.Error(t, err)
-				require.Nil(t, res)
-				var e *Error
-				require.ErrorAs(t, err, &e)
-				require.Equal(t, BadRequest, e.StatusCode)
-				require.Equal(t, InvalidRequestError, e.ErrorCode)
-				require.Contains(t, e.Message, "email contains potentially dangerous content")
-			},
-		},
-		{
 			name: "Sign in failed when password is empty",
 			setup: func(t *testing.T) SignInRequest {
 				return SignInRequest{
@@ -296,24 +278,6 @@ func TestSignIn(t *testing.T) {
 				require.Equal(t, BadRequest, e.StatusCode)
 				require.Equal(t, InvalidRequestError, e.ErrorCode)
 				require.Contains(t, e.Message, "password must contain at least one symbol")
-			},
-		},
-		{
-			name: "Sign in failed when password contains SQL injection",
-			setup: func(t *testing.T) SignInRequest {
-				return SignInRequest{
-					Email:    email,
-					Password: "Password123!'; DROP TABLE users; --",
-				}
-			},
-			check: func(t *testing.T, req SignInRequest, res *SignInResponse, err error) {
-				require.Error(t, err)
-				require.Nil(t, res)
-				var e *Error
-				require.ErrorAs(t, err, &e)
-				require.Equal(t, BadRequest, e.StatusCode)
-				require.Equal(t, InvalidRequestError, e.ErrorCode)
-				require.Contains(t, e.Message, "password contains potentially dangerous content")
 			},
 		},
 		{

--- a/feature/user/usecase/sign_up_request.go
+++ b/feature/user/usecase/sign_up_request.go
@@ -32,9 +32,6 @@ func (r SignUpRequest) Validate() error {
 	if err := util.StringValidator(r.Name).ValidateLength(1, 100); err != nil {
 		return newError(BadRequest, InvalidRequestError, "name must be between 1 and 100 characters")
 	}
-	if err := util.StringValidator(r.Name).ValidateNoSQLInjection(); err != nil {
-		return newError(BadRequest, InvalidRequestError, "name contains potentially dangerous content")
-	}
 
 	// Email validation
 	if len(r.Email) == 0 {
@@ -42,9 +39,6 @@ func (r SignUpRequest) Validate() error {
 	}
 	if err := util.StringValidator(r.Email).ValidateEmail(); err != nil {
 		return newError(BadRequest, InvalidRequestError, "email has invalid format")
-	}
-	if err := util.StringValidator(r.Email).ValidateNoSQLInjection(); err != nil {
-		return newError(BadRequest, InvalidRequestError, "email contains potentially dangerous content")
 	}
 
 	// Password validation
@@ -54,17 +48,11 @@ func (r SignUpRequest) Validate() error {
 	if err := util.StringValidator(r.Password).ValidatePassword(); err != nil {
 		return newError(BadRequest, InvalidRequestError, err.Error())
 	}
-	if err := util.StringValidator(r.Password).ValidateNoSQLInjection(); err != nil {
-		return newError(BadRequest, InvalidRequestError, "password contains potentially dangerous content")
-	}
 
 	// IPAddress validation (optional but validate if provided)
 	if len(r.IPAddress) > 0 {
 		if net.ParseIP(r.IPAddress) == nil {
 			return newError(BadRequest, InvalidRequestError, "IP address has invalid format")
-		}
-		if err := util.StringValidator(r.IPAddress).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "IP address contains potentially dangerous content")
 		}
 	}
 
@@ -72,9 +60,6 @@ func (r SignUpRequest) Validate() error {
 	if len(r.UserAgent) > 0 {
 		if err := util.StringValidator(r.UserAgent).ValidateLength(0, 2048); err != nil {
 			return newError(BadRequest, InvalidRequestError, "user agent must be less than 2048 characters")
-		}
-		if err := util.StringValidator(r.UserAgent).ValidateNoSQLInjection(); err != nil {
-			return newError(BadRequest, InvalidRequestError, "user agent contains potentially dangerous content")
 		}
 	}
 

--- a/util/string_validator.go
+++ b/util/string_validator.go
@@ -6,15 +6,14 @@ import (
 )
 
 var (
-	usernameRegex     = regexp.MustCompile(`^[A-Za-z0-9]{5,30}$`)
-	emailRegex        = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
-	upperCaseRegex    = regexp.MustCompile(`[A-Z]`)
-	lowerCaseRegex    = regexp.MustCompile(`[a-z]`)
-	digitRegex        = regexp.MustCompile(`[0-9]`)
-	symbolRegex       = regexp.MustCompile(`[\-^$*.@]`)
-	urlRegex          = regexp.MustCompile(`^https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,}(/.*)?$`)
-	isbnRegex         = regexp.MustCompile(`^[0-9]{13}$`)
-	sqlInjectionRegex = regexp.MustCompile(`(?i)(select|insert|update|delete|drop|create|alter|exec|union|script|javascript|<script|</script>|--|;|/\*|\*/|'.*'|".*")`)
+	usernameRegex  = regexp.MustCompile(`^[A-Za-z0-9]{5,30}$`)
+	emailRegex     = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+	upperCaseRegex = regexp.MustCompile(`[A-Z]`)
+	lowerCaseRegex = regexp.MustCompile(`[a-z]`)
+	digitRegex     = regexp.MustCompile(`[0-9]`)
+	symbolRegex    = regexp.MustCompile(`[\-^$*.@]`)
+	urlRegex       = regexp.MustCompile(`^https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,}(/.*)?$`)
+	isbnRegex      = regexp.MustCompile(`^[0-9]{13}$`)
 )
 
 type StringValidator string
@@ -89,11 +88,4 @@ func (s StringValidator) ValidateURL() error {
 
 func (s StringValidator) ValidateISBN() error {
 	return s.validateRegex(isbnRegex)
-}
-
-func (s StringValidator) ValidateNoSQLInjection() error {
-	if sqlInjectionRegex.MatchString(string(s)) {
-		return fmt.Errorf("potentially dangerous content detected")
-	}
-	return nil
 }


### PR DESCRIPTION
プレースホルダー対応していたため

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 入力フィールドに対するSQLインジェクションやスクリプトインジェクション検証が削除され、従来のフォーマットや長さ、パスワードなどのバリデーションのみが適用されるようになりました。

* **テスト**
  * 入力値にSQLインジェクションパターンが含まれる場合のエラーを検証するテストケースが削除されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->